### PR TITLE
Update docker image to python:3.7.10-slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+* Upgraded python in Docker image from 3.7.3 (stretch) to 3.7.10 (buster)
+
 ## 1.3.13 (2020-02-08)
 * Fix an issue where `metadata` were checked before `values` on [When its property does not have something](https://terraform-compliance.com/pages/bdd-references/when.html#when-its-property-has-not-something) ([#451](https://github.com/terraform-compliance/cli/pull/451))
 * Improve [exclude tag](https://terraform-compliance.com/pages/bdd-references/using_tags/#supported-tags) to support basix regular expressions ([#448](https://github.com/terraform-compliance/cli/pull/448))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-slim
+FROM python:3.7.10-slim
 
 ARG VERSION
 ARG LATEST_TERRAFORM_VERSION


### PR DESCRIPTION
Update docker image to python:3.7.10-slim. Note that python:3.7.10 is based on buster whereas python:3.7.3 was based on stretch.