### PR TITLE
Add missing --terraform option to docs

### DIFF
--- a/docs/pages/usage/index.md
+++ b/docs/pages/usage/index.md
@@ -20,6 +20,7 @@ cli parameters.
   
   usage: terraform-compliance [-h] --features feature directory --planfile
                               plan_file [--identity [ssh private key]]
+                              [--terraform [terraform_file]]
                               [--version]
   
   BDD Test Framework for Hashicorp terraform


### PR DESCRIPTION
It's listed in the details but not the initial section