### PR TITLE
Note that https git source can be used for private repos if configured

### DIFF
--- a/docs/pages/usage/index.md
+++ b/docs/pages/usage/index.md
@@ -55,7 +55,7 @@ All files within the directory (or repository) will be processed non-recursively
 
 or for a `git` repository ; (highly recommended for segregation of duties and having immutable features!)
 
-If the repository is a public repository ;
+If the repository is a public repository or credentials are available in the configured git credential manager ;
 
 ```shell
 [~] $ terraform-compliance -f git:https://github.com/user/repo ...


### PR DESCRIPTION
It worked fine for a https source when I had already got the credentials available in the configured git credential manager