### PR TITLE
Fixing a problem while reading the plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Fixed an issue where [exclude resources tag](https://terraform-compliance.com/pages/bdd-references/using_tags.html#exclude-resources) were breaking due to improper `step_obj` creation from `Given` step. ([#468](https://github.com/terraform-compliance/cli/issues/468))
 * Disabled ssh host key checking for private repositories ([#474](https://github.com/terraform-compliance/cli/issues/474))
+* Fixed an issue where some complicated `plan.out.json` files were creating problems while getting parsed. Also improved performance especially on large plan files.
 
 ## 1.3.14 (2020-04-15)
 * Upgraded python in Docker image from 3.7.3 (stretch) to 3.7.10 (buster)

--- a/terraform_compliance/common/readable_plan.py
+++ b/terraform_compliance/common/readable_plan.py
@@ -1,7 +1,7 @@
 import sys
 import os
 from argparse import Action
-import json
+import orjson
 import filetype
 from terraform_compliance.common.terraform_files import convert_terraform_plan_to_json
 from terraform_compliance.common.exceptions import TerraformComplianceInternalFailure
@@ -37,8 +37,7 @@ class ReadablePlan(Action):
 
         # Check if the given file is a json file.
         try:
-            with open(values, 'r', encoding='utf-8') as plan_file:
-                plan_lines = plan_file.read().splitlines()
+            plan_lines = [line for line in open(values, 'r', encoding='utf-8')]
 
             # Some Github Actions (hashicorp/setup-terraform) has internal wrappers which is
             # breaking the json file that is read by the terraform-compliance
@@ -49,14 +48,14 @@ class ReadablePlan(Action):
             else:
                 plan_lines = plan_lines[0]
 
-            data = json.loads(plan_lines)
+            data = orjson.loads(plan_lines)
 
             # Write the changed plan file to the same file, since it is used in other places.
             if file_change_required:
                 with open(values, 'w', encoding='utf-8') as plan_file:
                     plan_file.write(plan_lines)
 
-        except json.decoder.JSONDecodeError:
+        except orjson.JSONDecodeError:
             print('ERROR: {} is not a valid JSON file'.format(values))
             sys.exit(1)
         except UnicodeDecodeError:


### PR DESCRIPTION
This PR will fixes some edge cases where `.splitlines()` fails on complicated JSON files. 

Additionaly, we switched from slow native `json` library to `orjson` library. That will increase the performance on very large plan files.