### PR TITLE
Encourage the usage of when it has

### DIFF
--- a/docs/pages/Examples/AWS/security_groups.md
+++ b/docs/pages/Examples/AWS/security_groups.md
@@ -30,7 +30,8 @@ AWS
 ```gherkin
 Scenario Outline: Well-known insecure protocol exposure on Public Network for ingress traffic
     Given I have AWS Security Group defined
-  	When it contains ingress
+    When it has ingress
+    Then it must have ingress
     Then it must not have <proto> protocol and port <portNumber> for 0.0.0.0/0
 
 
@@ -51,7 +52,8 @@ Scenario Outline: Well-known insecure protocol exposure on Public Network for in
 ```gherkin
 Scenario: No publicly open ports
     Given I have AWS Security Group defined
-    When it contains ingress
+    When it has ingress
+    Then it must have ingress
     Then it must not have tcp protocol and port 1024-65535 for 0.0.0.0/0
 ```
 
@@ -60,6 +62,7 @@ Scenario: No publicly open ports
 ```gherkin
 Scenario: Only selected ports should be publicly open
     Given I have AWS Security Group defined
-    When it contains ingress
+    When it has ingress
+    Then it must have ingress
     Then it must only have tcp protocol and port 22,443 for 0.0.0.0/0
 ```

--- a/docs/pages/Examples/AWS/tags_related.md
+++ b/docs/pages/Examples/AWS/tags_related.md
@@ -34,7 +34,8 @@ AWS
 ```gherkin
   Scenario Outline: Ensure that specific tags are defined
     Given I have resource that supports tags defined
-    When it contains tags
+    When it has tags
+    Then it must contain tags
     Then it must contain <tags>
     And its value must match the "<value>" regex
 

--- a/docs/pages/Examples/AWS/vpc_peering.md
+++ b/docs/pages/Examples/AWS/vpc_peering.md
@@ -17,7 +17,8 @@ AWS
 ```gherkin
 Scenario Outline: Owner and Peer Validation
     Given I have aws_vpc_peering_connection defined
-    When it contains <key>
+    When it has <key>
+    Then it must have <key>
     Then its value must match the "<value>" regex
 
   Examples:

--- a/docs/pages/Examples/Azure/naming_standards.md
+++ b/docs/pages/Examples/Azure/naming_standards.md
@@ -17,8 +17,8 @@ AWS
 ```gherkin
   Scenario Outline: Naming Standard on all available resources
     Given I have <resource_name> defined
-    When it contains <name_key>
-    Then it must have name
+    When it has <name_key>
+    Then it must have <name_key>
     Then its value must match the "myproject-(prod|uat|dev)-someapplication-.*" regex
 
     Examples:

--- a/docs/pages/bdd-references/then.md
+++ b/docs/pages/bdd-references/then.md
@@ -159,7 +159,7 @@ must be enabled
 
 
 `encryption at rest` and `encryption in flight` are templated property types to help you to increase
-the readability of your BDD test. Please check [templated entities](/pages/bdd-references/templated_entities) 
+the readability of your BDD test. Please check [templated entities](/pages/bdd-references/template_entities.html) 
 section for more information.
 
 ------------------------

--- a/docs/pages/bdd-references/then.md
+++ b/docs/pages/bdd-references/then.md
@@ -416,7 +416,7 @@ it must fail
 ------------------------
 ### [Then](#){: .p-1 .text-red-200} it must have [address](#){: .p-1 .text-green-200 .fw-700} referenced
 `terraform-compliance` mounts resources into each other if they are referenced. E.g. an `aws_security_group_rule` onto
-`aws_security_grouup`. Some use cases may require to find these references, mount points about which entity is mounted 
+`aws_security_group`. Some use cases may require to find these references, mount points about which entity is mounted 
 on top of which entity. This step can be used in these situations.
 
 > __Possible sentences :__

--- a/docs/pages/bdd-references/when.md
+++ b/docs/pages/bdd-references/when.md
@@ -56,6 +56,8 @@ not met with the infrastructure plan.
 will be deprecated soon
 {: .label .label-blue}
 
+This step filters and drills down at the same time, unlike other WHEN steps. Please use [`When it has something`](https://terraform-compliance.com/pages/bdd-references/when.html#when-it-has-something) followed by [`Then it must have something`](https://terraform-compliance.com/pages/bdd-references/then.html#then-it-must-contain-something) to achieve a similar functionality.
+
 > __Possible sentences :__
 >
 > ▪


### PR DESCRIPTION
Add explanation on why [When it contains](https://terraform-compliance.com/pages/bdd-references/when.html#when-it-contains-something) is discouraged and what to use instead.

Remove instances of [When it contains](https://terraform-compliance.com/pages/bdd-references/when.html#when-it-contains-something) from examples to prevent encouraging the usage of it.