### PR TITLE
Move orjson to be an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@
 - __segregation of duty:__ you can keep your tests in a different repository where a separate team is responsible. 
 - __why ?:__ why not ?
 
+## Performance
+
+If terraform-compliance is not running quickly enough make sure to check the
+optional faster\_parsing pip install flag in the [Installation Guide](https://terraform-compliance.com/pages/installation/)
+
 ## Idea
 
 `terraform-compliance` mainly focuses on [negative testing](https://en.wikipedia.org/wiki/Negative_testing) instead

--- a/docs/pages/installation/pip.md
+++ b/docs/pages/installation/pip.md
@@ -16,6 +16,12 @@ It requires Python 3.x to run properly. Installation is pretty standard like any
 [~] $ pip install terraform-compliance
 ```
 
+or for faster parsing support (requires orjson)
+
+```shell
+[~] $ pip install terraform-compliance[faster_parsing]
+```
+
 in some use cases, you may want to create a new virtual environment to encapsulate `terraform-compliance`
 installation in your `venv` directory. In order to do that ;
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ dependencies = [
     'semver>=2.10.2',
     'IPython==7.16.1',
     'diskcache==5.1.0',
-    'orjson==3.5.2'
 ]
 
 setup(
@@ -59,5 +58,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
+    ],
+    extra_require = {
+        "faster_parsing": ["orjson"],
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    extra_require = {
+    extras_require = {
         "faster_parsing": ["orjson"],
     }
 )

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -8,7 +8,10 @@ from terraform_compliance.common.exceptions import TerraformComplianceInternalFa
 from semver import VersionInfo, compare
 from terraform_compliance.common.defaults import Defaults
 from radish.utils import console_write
-import orjson
+try:
+    import orjson as json
+except ImportError:
+    import json
 
 
 class EmptyStash(object):
@@ -370,8 +373,8 @@ def jsonify(string):
         return string
 
     try:
-        return orjson.loads(string)
-    except orjson.JSONDecodeError:
+        return json.loads(string)
+    except json.JSONDecodeError:
         return string
 
 

--- a/terraform_compliance/common/readable_plan.py
+++ b/terraform_compliance/common/readable_plan.py
@@ -1,10 +1,14 @@
 import sys
 import os
 from argparse import Action
-import orjson
 import filetype
 from terraform_compliance.common.terraform_files import convert_terraform_plan_to_json
 from terraform_compliance.common.exceptions import TerraformComplianceInternalFailure
+
+try:
+    import orjson as json
+except ImportError:
+    import json
 
 
 class ReadablePlan(Action):
@@ -48,14 +52,14 @@ class ReadablePlan(Action):
             else:
                 plan_lines = plan_lines[0]
 
-            data = orjson.loads(plan_lines)
+            data = json.loads(plan_lines)
 
             # Write the changed plan file to the same file, since it is used in other places.
             if file_change_required:
                 with open(values, 'w', encoding='utf-8') as plan_file:
                     plan_file.write(plan_lines)
 
-        except orjson.JSONDecodeError:
+        except json.JSONDecodeError:
             print('ERROR: {} is not a valid JSON file'.format(values))
             sys.exit(1)
         except UnicodeDecodeError:


### PR DESCRIPTION
Use it if available for faster parsing but for those less keen on using
a multi stage docker build and ensuring they have the correct shared
library dependencies (particularly challenging if building off an alpine
container that doesn't use a distribution build) they can avoid the
extra_requirement.