### PR TITLE
Update tags examples to expand to tags_all

### DIFF
--- a/docs/pages/Examples/AWS/tags_related.md
+++ b/docs/pages/Examples/AWS/tags_related.md
@@ -36,7 +36,25 @@ AWS
     Given I have resource that supports tags defined
     When it has tags
     Then it must contain tags
-    Then it must contain <tags>
+    Then it must contain "<tags>"
+    And its value must match the "<value>" regex
+
+    Examples:
+      | tags        | value              |
+      | Name        | .+                 |
+      | application | .+                 |
+      | role        | .+                 |
+      | environment | ^(prod\|uat\|dev)$ |
+```
+
+## Ensure that specific tags are defined for the tags_all attribute
+### https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#propagating-tags-to-all-resources
+```gherkin
+  Scenario Outline: Ensure that specific tags are defined
+    Given I have resource that supports tags_all defined
+    When it has tags_all
+    Then it must contain tags_all
+    Then it must contain "<tags>"
     And its value must match the "<value>" regex
 
     Examples:


### PR DESCRIPTION
Updating examples to reflect the supportability of the tags_all readonly attribute for aws terraform providers
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#propagating-tags-to-all-resources

Also quoting the <tags> variable placeholder as tags keys that have spaces break terraform compliance

Addresses #544