### PR TITLE
Regex support on `When its key has value`

### DIFF
--- a/docs/pages/bdd-references/when.md
+++ b/docs/pages/bdd-references/when.md
@@ -239,6 +239,60 @@ is
 | [value](#){: .p-1 .text-blue-100 .fw-700} | any dictionary value (allows spaces). | `my dictionary value` |
 
 ------------------------
+### [When](#){: .p-1 .text-red-200} its [property](#){: .p-1 .text-green-200 .fw-700} has \"[something]\"(#){: .p-1 .text-blue-100 .fw-700} regex
+This is a filtering function with regular expression support on values. Thus, found resources from previous step will be filtered based on these values.
+
+> __Possible sentences :__
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+is "[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+has
+"[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+> 
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+includes
+"[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+contains
+"[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[dictionary](#){: .p-1 .text-green-200 .fw-700}
+includes an entry where
+"
+[key](#){: .p-1 .text-blue-100 .fw-700}
+"
+is
+is "[value](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+>
+| key | Description | Examples |
+|:---:|:----------|:-|
+| [property](#){: .p-1 .text-green-200 .fw-700} | any property that resources have. Using `type` will give the Terraform resource type; `address` is the name you have given it | `address` `name` `size` |
+| [dictionary](#){: .p-1 .text-green-200 .fw-700} | a dictionary property that resource has. | `tags` |
+| [something](#){: .p-1 .text-blue-100 .fw-700} | Any regular expression | `aws_s3_.*"` |
+| [some string with spaces](#){: .p-1 .text-blue-100 .fw-700} | any string (allows spaces). | `my dictionary key` |
+| [key](#){: .p-1 .text-blue-100 .fw-700} | any dictionary key (allows spaces). | `my dictionary key` |
+| [value](#){: .p-1 .text-blue-100 .fw-700} | Any regular expression | `^4\\..*` |
+
+------------------------
 ### [When](#){: .p-1 .text-red-200} its [property](#){: .p-1 .text-green-200 .fw-700} has not [something](#){: .p-1 .text-blue-100 .fw-700}
 This is a filtering function. Thus, found resources from previous step will be filtered based on these values.
 
@@ -330,6 +384,60 @@ is
 | [some string with spaces](#){: .p-1 .text-blue-100 .fw-700} | any string (allows spaces). | `my dictionary key` |
 | [key](#){: .p-1 .text-blue-100 .fw-700} | any dictionary key (allows spaces). | `my dictionary key` |
 | [value](#){: .p-1 .text-blue-100 .fw-700} | any dictionary value (allows spaces). | `my dictionary value` |
+
+### [When](#){: .p-1 .text-red-200} its [property](#){: .p-1 .text-green-200 .fw-700} has not \"[something]\"(#){: .p-1 .text-blue-100 .fw-700} regex
+This is a filtering function with regular expression support on values. Thus, found resources from previous step will be filtered based on these values.
+
+> __Possible sentences :__
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+is not "[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+has
+not "[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+> 
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+does not include
+"[something](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[property](#){: .p-1 .text-green-200 .fw-700}
+does not contain
+"[something](#){: .p-1 .text-blue-100 .fw-700}" 
+regex
+>
+> ▪
+[When](#){: .p-1 .text-red-200}
+its
+[dictionary](#){: .p-1 .text-green-200 .fw-700}
+does not include an entry where
+"
+[key](#){: .p-1 .text-blue-100 .fw-700}
+"
+is
+is "[value](#){: .p-1 .text-blue-100 .fw-700}" regex
+>
+>
+| key | Description | Examples |
+|:---:|:----------|:-|
+| [property](#){: .p-1 .text-green-200 .fw-700} | any property that resources have. Using `type` will give the Terraform resource type; `address` is the name you have given it | `address` `name` `size` |
+| [dictionary](#){: .p-1 .text-green-200 .fw-700} | a dictionary property that resource has. | `tags` |
+| [something](#){: .p-1 .text-blue-100 .fw-700} | Any regular expression | `aws_s3_.*"` |
+| [some string with spaces](#){: .p-1 .text-blue-100 .fw-700} | any string (allows spaces). | `my dictionary key` |
+| [key](#){: .p-1 .text-blue-100 .fw-700} | any dictionary key (allows spaces). | `my dictionary key` |
+| [value](#){: .p-1 .text-blue-100 .fw-700} | Any regular expression | `^4\\..*` |
 
 ------------------------
 ### [When](#){: .p-1 .text-red-200} its [property](#){: .p-1 .text-green-200 .fw-700} metadata has [something](#){: .p-1 .text-blue-100 .fw-700}

--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -23,17 +23,22 @@ class Null(object):
 
 
 class Match(object):
-    def __init__(self, case_sensitive):
+    def __init__(self, case_sensitive, regex_flag=Null):
         self.case_sensitive = case_sensitive
+        self.regex_flag = regex_flag
 
     def equals(self, left, right):
         if not isinstance(left, (bool, int, float, str)) or not isinstance(right, (bool, int, float, str)):
             raise TypeError
 
-        if self.case_sensitive:
-            return str(left) == str(right)
-        else:
-            return str(left).lower() == str(right).lower()
+        if self.regex_flag: # Regex enabled matches
+            re_flag = 0 if self.case_sensitive else re.IGNORECASE
+            return True if re.match(right, left, flags=re_flag) else False
+        else: # Regex disabled matches
+            if self.case_sensitive:
+                return str(left) == str(right)
+            else:
+                return str(left).lower() == str(right).lower()
 
     # gets something from a dictionary
     # needle == key

--- a/terraform_compliance/extensions/override_radish_hookerrors.py
+++ b/terraform_compliance/extensions/override_radish_hookerrors.py
@@ -82,7 +82,7 @@ def handle_radish_errors(error_text):
         },
         {
             'class': StepDefinitionNotFoundError,
-            'text': '{}. Looks like a syntax error.'.format(str(error_text).split('\n')[3])
+            'text': '{}. Looks like a syntax error.'.format(str(error_text).split('\n'))
         },
     ]
 

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -144,10 +144,10 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
 
     try:
         result = call_radish(args=commands[1:])
+        return result
     except IndexError as e:
-        print(e)
-
-    return result
+        print("FATAL ERROR: It looks like there is a syntax error on your feature file.")
+    return
 
 
 if __name__ == '__main__':

--- a/terraform_compliance/steps/steps.py
+++ b/terraform_compliance/steps/steps.py
@@ -84,7 +84,19 @@ def wrapper(_step_obj, key, value):
 @when(u'its {address:PROPERTY} {key:PROPERTY} contains {value:PROPERTY}')
 @when(u'its {key:PROPERTY} includes an entry where {value:PROPERTY} is {dict_value:PROPERTY}')
 def wrapper(_step_obj, key, value, dict_value=None, address=Null):
-    return its_key_is_value(_step_obj, key, value, dict_value, address)
+    return its_key_is_value(_step_obj, key, value, dict_value, address, regex_flag=False)
+
+@when(u'its {key:PROPERTY} is "{search_regex}" regex')
+@when(u'its {key:PROPERTY} has "{search_regex}" regex')
+@when(u'its {key:PROPERTY} includes "{search_regex}" regex')
+@when(u'its {key:PROPERTY} contains "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} is "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} has "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} includes "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} contains "{search_regex}" regex')
+@when(u'its {key:PROPERTY} includes an entry where {value:PROPERTY} is "{dict_value}" regex')
+def wrapper(_step_obj, key, search_regex, dict_value=None, address=Null):
+    return its_key_is_value(_step_obj, key, search_regex, dict_value, address, regex_flag=True)
 
 
 @when(u'its {key:PROPERTY} is not {value:PROPERTY}')
@@ -97,8 +109,19 @@ def wrapper(_step_obj, key, value, dict_value=None, address=Null):
 @when(u'its {address:PROPERTY} {key:PROPERTY} does not contain {value:PROPERTY}')
 @when(u'its {key:PROPERTY} does not include an entry where {value:PROPERTY} is {dict_value:PROPERTY}')
 def wrapper(_step_obj, key, value, dict_value=None, address=Null):
-    return its_key_is_not_value(_step_obj, key, value, dict_value, address)
+    return its_key_is_not_value(_step_obj, key, value, dict_value, address, regex_flag=False)
 
+@when(u'its {key:PROPERTY} is not "{search_regex}" regex')
+@when(u'its {key:PROPERTY} has not "{search_regex}" regex')
+@when(u'its {key:PROPERTY} does not include "{search_regex}" regex')
+@when(u'its {key:PROPERTY} does not contain "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} is not "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} has not "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} does not include "{search_regex}" regex')
+@when(u'its {address:PROPERTY} {key:PROPERTY} does not contain "{search_regex}" regex')
+@when(u'its {key:PROPERTY} does not include an entry where {value:PROPERTY} is "{dict_value}" regex')
+def wrapper(_step_obj, key, search_regex, dict_value=None, address=Null):
+    return its_key_is_not_value(_step_obj, key, search_regex, dict_value, address, regex_flag=True)
 
 @when(u'it contain {something:PROPERTY}') # This is just here for not breaking backward compatibility. I know its wrong.
 @when(u'it contains {something:PROPERTY}')

--- a/terraform_compliance/steps/when/its_key_is_value.py
+++ b/terraform_compliance/steps/when/its_key_is_value.py
@@ -8,8 +8,9 @@ from terraform_compliance.common.helper import (
 from terraform_compliance.extensions.ext_radish_bdd import skip_step
 
 
-def its_key_is_value(_step_obj, key, value, dict_value=None, address=Null):
+def its_key_is_value(_step_obj, key, value, dict_value=None, address=Null, regex_match=Null):
     match = _step_obj.context.match
+    match.regex_flag = regex_match
     
     orig_key = key
     if key == 'reference':
@@ -76,8 +77,9 @@ def its_key_is_value(_step_obj, key, value, dict_value=None, address=Null):
                                                                                ', '.join(_step_obj.context.addresses)))
 
 
-def its_key_is_not_value(_step_obj, key, value, dict_value=None, address=Null):
+def its_key_is_not_value(_step_obj, key, value, dict_value=None, address=Null, regex_flag=Null):
     match = _step_obj.context.match
+    match.regex_flag = regex_flag
     
     orig_key = key
     if key == 'reference':


### PR DESCRIPTION
This PR will adds two new steps for supporting regular expression matching on some of the `When` directives ;

```cucumber
  When its key is "regex pattern" regex`
  When its key is not "regex pattern" regex`
```

along with all the combinations. 