### PR TITLE
Simplify support for running module directly

### DIFF
--- a/terraform_compliance/__main__.py
+++ b/terraform_compliance/__main__.py
@@ -1,0 +1,3 @@
+from .main import cli
+
+cli()


### PR DESCRIPTION
I expected to be able to do `python -m terraform_compliance` as we would with pip or other python tools, but it didn't work. Instead I had to do `python -m terraform_compliance.main`.

This fixes that problem.