### PR TITLE
Bump diskcache in setup.py as in requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dependencies = [
     'mock>=3.0.5',
     'semver>=2.10.2',
     'IPython==7.16.1',
-    'diskcache==5.1.0',
+    'diskcache==5.4.0',
 ]
 
 setup(


### PR DESCRIPTION
dependabot has bumped `diskcache` to `5.4.0` in `requirements.txt`, but the version in `setup.py` still requires `==5.1.0`. This PR bumps the version in `setup.py` to match.