### PR TITLE
fix: replace mock module with unittest.mock

### DIFF
--- a/terraform_compliance/common/error_handling.py
+++ b/terraform_compliance/common/error_handling.py
@@ -4,7 +4,7 @@ from radish.utils import console_write
 from terraform_compliance.main import Step
 import colorful
 from ast import literal_eval
-from mock import MagicMock
+from unittest.mock import MagicMock
 import os
 
 


### PR DESCRIPTION
Hi @eerkunt,

In [1.3.35](https://github.com/terraform-compliance/cli/compare/1.3.34...1.3.35#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L17) external `mock` module was removed from the dependency list, but the import wasn't updated in `common/error_handling.py` where it's requested. This predictably results in `No module named 'mock'` error.

This PR fixes the import statement.

Cheers!👍