### PR TITLE
fix: replace mock module with unittest.mock

### DIFF
--- a/terraform_compliance/common/error_handling.py
+++ b/terraform_compliance/common/error_handling.py
@@ -4,7 +4,7 @@ from radish.utils import console_write
 from terraform_compliance.main import Step
 import colorful
 from ast import literal_eval
-from mock import MagicMock
+from unittest.mock import MagicMock
 import os
 
 

--- a/tests/terraform_compliance/steps/test_main_steps.py
+++ b/tests/terraform_compliance/steps/test_main_steps.py
@@ -16,7 +16,7 @@ from terraform_compliance.steps.steps import (
 )
 from terraform_compliance.common.exceptions import TerraformComplianceNotImplemented, Failure
 from tests.mocks import MockedStep, MockedWorld
-from mock import patch
+from unittest.mock import patch
 
 
 class TestStepCases(TestCase):


### PR DESCRIPTION
As in #666, also with fixed imports in tests.

fixes #667