### PR TITLE
fix(setup): add mock as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ dependencies = [
     'semver==2.13.0',
     'IPython==7.16.1',
     'orjson==3.8.3',
+    'mock==5.0.0',
     'diskcache==5.4.0'
 ]
 


### PR DESCRIPTION
Mock is a needed dependency of terraform-compliance used in terraform_compliance.common.error_handling

With last release of terraform-compliance (1.3.37) our ci jobs are failing due to the import issue:

```
! ERROR: Unable to import module 'steps' from '/usr/local/lib/python3.10/dist-packages/terraform_compliance/steps/steps.py': No module named 'mock'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/radish/loader.py", line 43, in load_module
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/local/lib/python3.10/dist-packages/terraform_compliance/steps/steps.py", line 14, in <module>
    from terraform_compliance.common.error_handling import Error
  File "/usr/local/lib/python3.10/dist-packages/terraform_compliance/common/error_handling.py", line 7, in <module>
    from mock import MagicMock
ModuleNotFoundError: No module named 'mock'
```