### PR TITLE
Add documentation for CircleCI and GitHub Actions integrations

### DIFF
--- a/docs/pages/bdd-references/index.md
+++ b/docs/pages/bdd-references/index.md
@@ -29,7 +29,7 @@ Feature: Security Groups should be used to protect services/instances
   We'll use AWS Security Groups as a Perimeter Defence
 ```
 
-This won't effect anything about the test steps, but it will ease the pain for everybody to 
+This won't affect anything about the test steps, but it will ease the pain for everybody to 
 understand what does that feature aims for.
 
 ### Scenario

--- a/docs/pages/bdd-references/using_tags.md
+++ b/docs/pages/bdd-references/using_tags.md
@@ -81,7 +81,7 @@ __Please note that__
 - nofail and noskip tags can not be used within the same scenario.
 
 ### Case Sensitivity
-All steps, under the tagged scenario will use case sensitive matching. This tag also effects regular expressions.
+All steps, under the tagged scenario will use case-sensitive matching. This tag also affects regular expressions.
 > __Possible formats:__
 >
 > ▪

--- a/docs/pages/ci-cd/circle_ci.md
+++ b/docs/pages/ci-cd/circle_ci.md
@@ -28,11 +28,16 @@ We have set up our pipeline to follow this basic workflow:
 You will need to add a `requirements.txt` to your project. You can rename this file to anything you would like, but
 be sure to update the name in your `.circleci/config.yml`.
 
+Following [Pip requirements format](https://pip.pypa.io/en/stable/reference/requirements-file-format/). You can specify
+any level of requirement that you desire for `terraform-compliance`.
+
 `requirements.txt`:
 
 ```
 terraform-compliance >= 1.3.0
 ```
+
+Below is an example of the workflow described above.
 
 `.circleci/config.yml`:
 

--- a/docs/pages/ci-cd/circle_ci.md
+++ b/docs/pages/ci-cd/circle_ci.md
@@ -143,3 +143,8 @@ workflows:
             - terraform_compliance
 
 ```
+
+Not provided above is the authentication method for AWS.
+
+CircleCI provides authentication through [OpenID Connect](https://circleci.com/blog/openid-connect-identity-tokens/) as
+well as through AWS user Access Keys.

--- a/docs/pages/ci-cd/circle_ci.md
+++ b/docs/pages/ci-cd/circle_ci.md
@@ -1,0 +1,140 @@
+---
+layout: default
+title: CircleCI
+nav_order: 1
+has_children: false
+parent: Using in CI/CD
+---
+
+# CircleCI
+
+For this example, we are using the following Orbs to illustrate how you might implement Terraform Compliance into your
+CI/CD pipeline.
+
+- [circleci/terraform](https://circleci.com/developer/orbs/orb/circleci/terraform)
+- [circleci/python](https://circleci.com/developer/orbs/orb/circleci/python)
+
+## Workflow
+
+We have set up our pipeline to follow this basic workflow:
+
+1. `terraform validate`: Using the Job provided by the Terraform Orb
+2. `terraform plan`: Using a custom Job, we will use the `plan` command that is provided by the Terraform Orb, but we'll also export that plan to json for `terraform-compliance` to access
+3. `terraform-compliance`: Using the Python Orb and Pip to install requirements
+4. `terraform apply`: Using the Job provided by the Terraform Orb, and only run on the `main` branch
+
+## Setup
+
+You will need to add a `requirements.txt` to your project. You can rename this file to anything you would like, but
+be sure to update the name in your `.circleci/config.yml`.
+
+`requirements.txt`:
+
+```
+terraform-compliance >= 1.3.0
+```
+
+`.circleci/config.yml`:
+
+```yaml
+version: '2.1'
+
+orbs:
+  # Orb used for all of our Terraform related commands/jobs
+  # https://circleci.com/developer/orbs/orb/circleci/terraform for available versions
+  terraform: circleci/terraform@3.2.1
+  # Orb used for installing and running Terraform Compliance
+  # https://circleci.com/developer/orbs/orb/circleci/python for available versions
+  python: circleci/python@2.1.1
+
+parameters:
+  terraform-tag:
+    type: string
+    description: Specify the Terraform Docker image tag for the executor
+    # https://hub.docker.com/r/hashicorp/terraform/tags for available versions
+    # If you also run Terraform locally, then you should use the same version here
+    default: 1.5.7
+  workspace-root:
+    type: string
+    description: Path of the workspace to persist to relative to workspace-root
+    # Can be updated if you desire. The default specified here matches the default used by the CircleCI's Terraform Orb
+    default: .
+  workspace-path:
+    type: string
+    description: Workspace root path that is either an absolute path or a path relative to the working directory
+    # Can be updated if you desire. The default specified here matches the default used by the CircleCI's Terraform Orb
+    default: .
+
+executors:
+  # This default executor is used for our custom job that needs to run Terraform
+  default:
+    docker:
+      # Our default executor should match the tag that the Terraform Orb will use
+      - image: hashicorp/terraform:<< pipeline.parameters.terraform-tag >>
+
+jobs:
+  terraform_plan:
+    executor: default
+    steps:
+      - checkout
+      # Invoke the terraform/plan command that is provided by the Terraform Orb
+      - terraform/plan:
+          # And also output that plan
+          out: plan.out
+      # Convert our plan to JSON so that terraform-compliance can run without the use of Terraform
+      - run:
+          command: terraform show -json plan.out > plan.out.json
+          name: Convert Terraform plan to JSON
+      # Persist our workspace so that plan.out.json is available to terraform-compliance
+      - persist_to_workspace:
+          paths:
+            - << pipeline.parameters.workspace-path >>
+          root: << pipeline.parameters.workspace-root >>
+
+  terraform_compliance:
+    executor: python/default
+    steps:
+      # Attach the workspace so that we have access to plan.out.json from terraform_plan
+      - attach_workspace:
+          at: << pipeline.parameters.workspace-root >>
+      - python/install-packages:
+          # Update requirements.txt to match the location of your requirements file. This is currently referencing a
+          # file in the root of your project
+          pip-dependency-file: requirements.txt
+          pkg-manager: pip
+      - run:
+          command: terraform-compliance -f features -p plan.out.json
+          name: Terraform Compliance
+
+workflows:
+  deploy_infra:
+    jobs:
+      # Use the standard validate job that is provided by the CircleCI Orb
+      - terraform/validate:
+          checkout: true
+          # Make sure the CircleCI Orb uses the same version of Terraform as our default executor
+          tag: << pipeline.parameters.terraform-tag >>
+
+      # For terraform plan we'll use a custom job so that we can run additional commands
+      - terraform_plan:
+          requires:
+            - terraform/validate
+
+      # For terraform-compliance we'll use another custom job, and this will also be using our Python executor
+      - terraform_compliance:
+          requires:
+            - terraform_plan
+
+      # Use the standard apply job that is provided by the CircleCI Orb
+      - terraform/apply:
+          attach-workspace: true
+          # Make sure the CircleCI Orb uses the same version of Terraform as our default executor
+          tag: << pipeline.parameters.terraform-tag >>
+          # Update your filters as you require. One provided here as an example
+          filters:
+            branches:
+              only: main
+          requires:
+            - terraform_compliance
+
+```

--- a/docs/pages/ci-cd/github_actions.md
+++ b/docs/pages/ci-cd/github_actions.md
@@ -1,0 +1,117 @@
+---
+layout: default
+title: GitHub Actions
+nav_order: 2
+has_children: false
+parent: Using in CI/CD
+---
+
+# GitHub Actions
+
+For this example, we'll use the following GitHub Marketplace Actions to illustrate how you might implement Terraform 
+Compliance into your CI/CD pipeline.
+
+## Workflow
+
+We have set up our job to follow this basic workflow:
+
+1. `terraform init`
+2. `terraform validate`
+3. `terraform plan`
+4. `terraform-compliance`
+5. `terraform apply` (but only on the `main` branch)
+
+## Setup
+
+You will need to add a `requirements.txt` to your project. You can rename this file to anything you would like, but
+be sure to update the name in your `.github/workflows/main.yml`.
+
+Following [Pip requirements format](https://pip.pypa.io/en/stable/reference/requirements-file-format/). You can specify
+any level of requirement that you desire for `terraform-compliance`.
+
+`requirements.txt`:
+
+```
+terraform-compliance >= 1.3.0
+```
+
+Below is an example of the workflow described above.
+
+`.github/workflows/main.yml`:
+
+```yaml
+name: Project Name
+
+# https://docs.github.com/en/actions/using-workflows/triggering-a-workflow for available triggers
+on:
+  # Run this workflow on all pull requests
+  pull_request:
+  # Run this workflow on commits made to the main branch 
+  push:
+    branches:
+      - main
+
+jobs:
+  test_and_deploy:
+    name: Deploy Infrastructure
+    runs-on: ubuntu-latest
+    # Required by aws-actions/configure-aws-credentials
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      # Checkout your code
+      - uses: actions/checkout@v4
+
+      # Set up our AWS credentials
+      - name: Configure AWS credentials
+        # https://github.com/aws-actions/configure-aws-credentials for available versions
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # Define authentication method
+          # Check the above repo for authentication methods available
+
+      # Set up Terraform for GitHub Actions
+      - name: Setup Terraform
+        # https://github.com/hashicorp/setup-terraform for available versions
+        uses: hashicorp/setup-terraform@v2
+        with:
+          # https://hub.docker.com/r/hashicorp/terraform/tags for available versions
+          # If you also run Terraform locally, then you should use the same version here
+          terraform_version: 1.5.7
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        # Run terraform plan with an output, and then convert that output to JSON for Terraform Compliance to use later
+        run: |
+          terraform plan -out=plan.out
+          terraform show -json plan.out > plan.out.json
+
+      # Set up Python
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: 'pip'
+
+      # Install Python requirements
+      - name: Install Requirements
+        # Update requirements.txt to match the location of your requirements file. This is currently referencing a
+        # file in the root of your project
+        run: pip install -r requirements.txt
+
+      - name: Terraform Compliance
+        run: terraform-compliance -f compliance -p plan.out.json
+
+      - name: Terraform Apply
+        # Only trigger this step on the main branch
+        if: github.ref == 'refs/heads/main'
+        run: terraform apply -auto-approve
+
+```

--- a/docs/pages/ci-cd/index.md
+++ b/docs/pages/ci-cd/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Using in CI/CD
+nav_order: 6
+has_children: true
+---

--- a/docs/pages/contribution/index.md
+++ b/docs/pages/contribution/index.md
@@ -30,12 +30,12 @@ If you are going to reporting something else, please create a [General Question]
 
 Normally, we expect to have either a [Bug Reporting](https://github.com/eerkunt/terraform-compliance/issues/new?assignees=eerkunt&labels=bug&template=bug_report.md&title=) or 
 a [Feature Request](https://github.com/eerkunt/terraform-compliance/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=) before 
-having a Pull Request for in the codebase that will effect any functionality. This is not a hard requirement, you are free
+having a Pull Request for in the codebase that will affect any functionality. This is not a hard requirement, you are free
 to create a new Pull Request if you find something is wrong or missing within the codebase or documentation. 
 
 There is few mandatory requirement for the Pull Requests ;
 
-1. All code changes that effects functionality MUST have [tests](https://github.com/eerkunt/terraform-compliance/tree/master/tests) implemented within the same Pull Request. 
+1. All code changes that affects functionality MUST have [tests](https://github.com/eerkunt/terraform-compliance/tree/master/tests) implemented within the same Pull Request. 
 2. Any functionality change must be recorded within the [CHANGELOG](https://github.com/eerkunt/terraform-compliance/blob/master/CHANGELOG.md).
 3. Your Pull Request must pass the CI in order to be processed.
 


### PR DESCRIPTION
Fixes #718
Closes #718

Provide some documentation on how a developer might integrate Terraform Compliance into a CircleCI pipeline and GitHub Actions.

Plus some minor changes for effect -> affect.