### PR TITLE
Return system exit code when running as module

### DIFF
--- a/terraform_compliance/__main__.py
+++ b/terraform_compliance/__main__.py
@@ -1,3 +1,5 @@
+import sys
+
 from .main import cli
 
-cli()
+sys.exit(cli())

--- a/terraform_compliance/main.py
+++ b/terraform_compliance/main.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import shutil
 import atexit
@@ -159,4 +160,4 @@ def cli(arghandling=ArgHandling(), argparser=ArgumentParser(prog=__app_name__,
 
 
 if __name__ == '__main__':
-    cli()
+    sys.exit(cli())


### PR DESCRIPTION
We've found that terraform compliance failures were not causing our builds to fail

We call terraform compliance using `python -m terraform_compliance`

I believe it works fine for the .exe mode since that calls `cli` directly and will handle the exit code from that automatically