### PR TITLE
Respond to github issue 777

### DIFF
--- a/tests/terraform_compliance/extensions/test_terraform.py
+++ b/tests/terraform_compliance/extensions/test_terraform.py
@@ -214,6 +214,53 @@ class TestTerraformParser(TestCase):
         self.assertEqual(obj.resources, {})
 
     @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_resources_deleted_state_resources_removed(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['values'] = {
+            'root_module': {
+                'resources': [
+                    {
+                        'address': 'something'
+                    }
+                ]
+            }
+        }
+        obj.raw['resource_changes'] = [
+            {
+                'address': 'something',
+                'change': {
+                    'actions': ['delete']
+                }
+            }
+        ]
+        obj._parse_resources()
+        self.assertEqual(obj.resources, {})
+
+    @patch.object(TerraformParser, '_read_file', return_value={})
+    def test_parse_resources_deleted_state_data_removed(self, *args):
+        obj = TerraformParser('somefile', parse_it=False)
+        obj.raw['values'] = {
+            'root_module': {
+                'resources': [
+                    {
+                        'address': 'data.something',
+                        'mode': 'data'
+                    }
+                ]
+            }
+        }
+        obj.raw['resource_changes'] = [
+            {
+                'address': 'data.something',
+                'change': {
+                    'actions': ['delete']
+                }
+            }
+        ]
+        obj._parse_resources()
+        self.assertEqual(obj.data, {})
+
+    @patch.object(TerraformParser, '_read_file', return_value={})
     def test_parse_configurations_resources(self, *args):
         obj = TerraformParser('somefile', parse_it=False)
         obj.raw['configuration'] = {


### PR DESCRIPTION
Remove resources scheduled for deletion from the parser's state to evaluate the plan's post-apply view.

This change ensures that `terraform-compliance` only evaluates resources that will exist after a `terraform apply`. If a resource violates policy but the plan removes it, the run will no longer fail, addressing issue #777.

---
<a href="https://cursor.com/background-agent?bcId=bc-117d040c-970c-4723-879b-05affb882ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-117d040c-970c-4723-879b-05affb882ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

