### PR TITLE
Fix github issue 752

### DIFF
--- a/terraform_compliance/common/helper.py
+++ b/terraform_compliance/common/helper.py
@@ -378,9 +378,15 @@ def jsonify(string):
         return string
 
     try:
-        return json.loads(string)
+        parsed = json.loads(string)
     except json.JSONDecodeError:
         return string
+
+    # Only convert when resulting structure is JSON (list/dict); keep primitives as strings.
+    if isinstance(parsed, (dict, list)):
+        return parsed
+
+    return string
 
 
 def recursive_jsonify(haystack):

--- a/tests/terraform_compliance/common/test_helper.py
+++ b/tests/terraform_compliance/common/test_helper.py
@@ -159,6 +159,8 @@ class TestHelperFunctions(TestCase):
         self.assertEqual(jsonify([]), [])
         self.assertEqual(jsonify(12), 12)
         self.assertEqual(jsonify('something'), 'something')
+        self.assertEqual(jsonify('1.30'), '1.30')
+        self.assertEqual(jsonify('10'), '10')
         self.assertEqual(jsonify('{"test": "test_value"}'), {'test': 'test_value'})
 
     def test_remove_mounted_resources(self, *args):


### PR DESCRIPTION
Prevent numeric-looking strings from being coerced into floats by the `jsonify` function to preserve version-like values.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0706c5f-92a9-404c-b477-93b2e588e2a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0706c5f-92a9-404c-b477-93b2e588e2a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

